### PR TITLE
babel plugin to support decorators

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": ["transform-decorators-legacy"]
 }

--- a/app/components/pages/people.jsx
+++ b/app/components/pages/people.jsx
@@ -6,8 +6,16 @@ import * as pageSlx from '../../selectors/pages/people';
 import * as peopleAx from '../../actions/people';
 
 
+let selector = createSelector(
+  pageSlx.people,
+  pageSlx.selectedPerson,
+  (people, selectedPerson) => (
+    {people, selectedPerson}
+  )
+);
 
-class PeopleIndex extends Component {
+@connect(selector)
+export default class PeopleIndex extends Component {
 
   /*
    *  UI EVENTS
@@ -45,15 +53,3 @@ class PeopleIndex extends Component {
   }
 
 }
-
-
-
-let selector = createSelector(
-  pageSlx.people,
-  pageSlx.selectedPerson,
-  (people, selectedPerson) => (
-    {people, selectedPerson}
-  )
-);
-
-export default connect(selector)(PeopleIndex);

--- a/app/components/pages/planet-profile.jsx
+++ b/app/components/pages/planet-profile.jsx
@@ -6,8 +6,13 @@ import { map } from 'lodash';
 import * as pageSlx from '../../selectors/pages/planet-profile';
 
 
+let selector = createSelector(
+  pageSlx.planet,
+  planet => ({planet})
+);
 
-class PlanetsShow extends Component {
+@connect(selector)
+export default class PlanetsShow extends Component {
 
   render() {
     let planet = this.props.planet;
@@ -26,12 +31,3 @@ class PlanetsShow extends Component {
   }
 
 }
-
-
-
-let selector = createSelector(
-  pageSlx.planet,
-  planet => ({planet})
-);
-
-export default connect(selector)(PlanetsShow);

--- a/app/components/pages/planets-index.jsx
+++ b/app/components/pages/planets-index.jsx
@@ -6,8 +6,13 @@ import { Link } from 'react-router';
 import * as pageSlx from '../../selectors/pages/planets-index';
 
 
+let selector = createSelector(
+  pageSlx.planets,
+  planets => ({planets})
+);
 
-class PlanetsIndex extends Component {
+@connect(selector)
+export default class PlanetsIndex extends Component {
 
   render() {
     let {planets} = this.props;
@@ -27,12 +32,3 @@ class PlanetsIndex extends Component {
   }
 
 }
-
-
-
-let selector = createSelector(
-  pageSlx.planets,
-  planets => ({planets})
-);
-
-export default connect(selector)(PlanetsIndex);

--- a/client/index.js
+++ b/client/index.js
@@ -7,7 +7,6 @@ import './globals';
 import configureRoutes from '../app/configure-routes';
 import configureStore from '../app/configure-store';
 import apiClient from '../app/api-client';
-import planetsSlx from '../app/selectors/planets';
 
 
 let store = configureStore();
@@ -30,6 +29,5 @@ match({routes, location}, (error, redirect, renderProps) => {
 window.App = {
   apiClient,
   store,
-  routes,
-  planetsSlx
+  routes
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.9.1",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",


### PR DESCRIPTION
This plugin helps wrap react components with connect using decorators.

ex.

@connect(selector)
export default class PeopleIndex extends Component {
  ...
}
